### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/PebbleKit/PebbleKit/src/main/AndroidManifest.xml
+++ b/PebbleKit/PebbleKit/src/main/AndroidManifest.xml
@@ -6,10 +6,6 @@
     <application android:label="@string/app_name" >
         <activity android:name="PEBBLE_KIT"
                   android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
         </activity>
     </application>
 </manifest> 


### PR DESCRIPTION
Remove the unnecessary intent-filter with "LAUNCHER" category. This will cause Android to generate two icons in launcher: one for your real app and one for PebbleKit (same icon).
