### PR TITLE
Do not use toLowerCase() for determining JSON keys.

### DIFF
--- a/PebbleKit/PebbleKit/src/main/java/com/getpebble/android/kit/util/PebbleTuple.java
+++ b/PebbleKit/PebbleKit/src/main/java/com/getpebble/android/kit/util/PebbleTuple.java
@@ -102,19 +102,21 @@ final class PebbleTuple {
     }
 
     static enum TupleType {
-        BYTES(0),
-        STRING(1),
-        UINT(2),
-        INT(3);
+        BYTES(0, "bytes"),
+        STRING(1, "string"),
+        UINT(2, "uint"),
+        INT(3, "int");
 
         public final byte ord;
+        private String name;
 
-        private TupleType(int ord) {
+        private TupleType(int ord, String name) {
             this.ord = (byte) ord;
+            this.name = name;
         }
 
         public String getName() {
-            return name().toLowerCase();
+            return name;
         }
     }
 }


### PR DESCRIPTION
toLowerCase() method in Android is Locale-dependent. That means that in some languages method may return different result than one expected. And since this is used to determine JSON keys, it may cause parsing failure.

Due to this issue, PebbleKit for Android does not work if your language is set to Turkish for example.
